### PR TITLE
Project name, document version & code clean up

### DIFF
--- a/Export for User Flows.sketchplugin
+++ b/Export for User Flows.sketchplugin
@@ -57,13 +57,11 @@ if (openPanel.runModal() == NSOKButton) {
     }
 
     // Ask the user for the name of the project
-    // TODO: Guess the project name based on the Sketch filename
-    var projectName = [doc askForUserInput:"What is this project called?" initialValue:""]
+    var projectName = [doc askForUserInput:"What is this project called?" initialValue:guessProjectName()]
     jsonObject[projectNameJSONKey] = new String(projectName)
 
     // Ask the user for the verson of the document
-    // TODO: Guess the project name based on the Sketch filename
-    var documentVersion = [doc askForUserInput:"What version of the document is this?" initialValue:""]
+    var documentVersion = [doc askForUserInput:"What version of the document is this?" initialValue:guessDocumentVersion()]
     jsonObject[documentVersionJSONKey] = new String(documentVersion)
 
     // Convert the descrptions object to JSON
@@ -73,6 +71,19 @@ if (openPanel.runModal() == NSOKButton) {
     // Save the descriptions to a JSON file
     var metadataFilePath = exportBaseUrl.URLByAppendingPathComponent(metadataFilename).path()
     [[NSFileManager defaultManager] createFileAtPath:metadataFilePath contents:jsonData attributes:nil]
+}
+
+function guessProjectName() {
+    return getFilenameWithoutExtension().componentsSeparatedByString("_").firstObject()
+}
+
+function guessDocumentVersion() {
+    return "Version " + getFilenameWithoutExtension().componentsSeparatedByString("_").lastObject()
+}
+
+function getFilenameWithoutExtension() {
+    var filename = doc.fileURL().lastPathComponent()
+    return [filename stringByReplacingOccurrencesOfString:".sketch" withString:""]
 }
 
 // A a layer inside the given layer group which has the name

--- a/Export for User Flows.sketchplugin
+++ b/Export for User Flows.sketchplugin
@@ -5,7 +5,11 @@ var userFlowDescriptionLayerName = "User Flow Description"
 // The file extension to export the images with
 var fileExtension = ".png"
 // The filename to use for the descriptions file
-var descriptionsFilename = "descriptions.json"
+var descriptionsFilename = "user_flows.json"
+// The key used to reference the descriptions in the JSON file
+var descriptionsJSONKey = "descriptions"
+// The key used to reference the project name in the JSON file
+var projectNameJSONKey = "projectName"
 
 // Ask the user where they want to export to
 var openPanel = NSOpenPanel.openPanel()
@@ -18,8 +22,11 @@ if (openPanel.runModal() == NSOKButton) {
     // Get the url of the folder the user selected
     var exportBaseUrl = openPanel.URL()
 
+    // Create an object to store the JSON data in
+    var jsonObject = {}
     // Create an object to store descriptions in
-    var descriptions = {}
+    jsonObject[descriptionsJSONKey] = {}
+    var descriptions = jsonObject[descriptionsJSONKey]
 
     // Loop through all the pages
     var pageLoop = doc.pages().objectEnumerator()
@@ -58,13 +65,20 @@ if (openPanel.runModal() == NSOKButton) {
         }
     }
 
+    // Ask the user for the name of the project
+    // TODO: Guess the project name based on the Sketch filename
+    var projectName = [doc askForUserInput:"What is this project called?" initialValue:""]
+
+    // Put the project name in the JSON object
+    jsonObject[projectNameJSONKey] = new String(projectName)
+
     // Convert the descrptions object to JSON
-    var descriptionsJSON = JSON.stringify(descriptions)
-    var descriptionsJSONData = @descriptionsJSON.dataUsingEncoding(NSUTF8StringEncoding))
+    var jsonString = JSON.stringify(jsonObject)
+    var jsonData = @jsonString.dataUsingEncoding(NSUTF8StringEncoding))
 
     // Save the descriptions to a JSON file
     var descriptionsFilePath = exportBaseUrl.URLByAppendingPathComponent(descriptionsFilename).path()
-    [[NSFileManager defaultManager] createFileAtPath:descriptionsFilePath contents:descriptionsJSONData attributes:nil]
+    [[NSFileManager defaultManager] createFileAtPath:descriptionsFilePath contents:jsonData attributes:nil]
 }
 
 // A a layer inside the given layer group which has the name

--- a/Export for User Flows.sketchplugin
+++ b/Export for User Flows.sketchplugin
@@ -59,9 +59,12 @@ if (openPanel.runModal() == NSOKButton) {
     // Ask the user for the name of the project
     // TODO: Guess the project name based on the Sketch filename
     var projectName = [doc askForUserInput:"What is this project called?" initialValue:""]
-
-    // Put the project name in the JSON object
     jsonObject[projectNameJSONKey] = new String(projectName)
+
+    // Ask the user for the verson of the document
+    // TODO: Guess the project name based on the Sketch filename
+    var documentVersion = [doc askForUserInput:"What version of the document is this?" initialValue:""]
+    jsonObject[documentVersionJSONKey] = new String(documentVersion)
 
     // Convert the descrptions object to JSON
     var jsonString = JSON.stringify(jsonObject)

--- a/Export for User Flows.sketchplugin
+++ b/Export for User Flows.sketchplugin
@@ -68,8 +68,8 @@ if (openPanel.runModal() == NSOKButton) {
     var jsonData = @jsonString.dataUsingEncoding(NSUTF8StringEncoding))
 
     // Save the descriptions to a JSON file
-    var descriptionsFilePath = exportBaseUrl.URLByAppendingPathComponent(descriptionsFilename).path()
-    [[NSFileManager defaultManager] createFileAtPath:descriptionsFilePath contents:jsonData attributes:nil]
+    var metadataFilePath = exportBaseUrl.URLByAppendingPathComponent(metadataFilename).path()
+    [[NSFileManager defaultManager] createFileAtPath:metadataFilePath contents:jsonData attributes:nil]
 }
 
 // A a layer inside the given layer group which has the name

--- a/Export for User Flows.sketchplugin
+++ b/Export for User Flows.sketchplugin
@@ -1,15 +1,6 @@
 // Export for User Flows (control shift e)
 
-// The name of the User Flow Description text layer
-var userFlowDescriptionLayerName = "User Flow Description"
-// The file extension to export the images with
-var fileExtension = ".png"
-// The filename to use for the descriptions file
-var descriptionsFilename = "user_flows.json"
-// The key used to reference the descriptions in the JSON file
-var descriptionsJSONKey = "descriptions"
-// The key used to reference the project name in the JSON file
-var projectNameJSONKey = "projectName"
+#import 'lib/constants.js'
 
 // Ask the user where they want to export to
 var openPanel = NSOpenPanel.openPanel()

--- a/Populate User Flows.sketchplugin
+++ b/Populate User Flows.sketchplugin
@@ -12,17 +12,21 @@ function init() {
 	var metadataString = [NSString stringWithContentsOfURL:metadataFilePath encoding:NSUTF8StringEncoding error:null]
     var metadata = JSON.parse(metadataString)
 
-	// Select first template page
-	var templatePage = getFirstTemplatePage()
+    // Get the project name from the metadata
+    var projectName = metadata[projectNameJSONKey]
+    // Get the descriptions from the metadata
+    var descriptions = metadata[descriptionsJSONKey]
 
+	// Select first template page
+	var templatePage = getPageByName(templatePageName)
 	// Get number of screens per page
 	var numberOfScreensPerPage = getScreensPerPageFromTemplate(templatePage)
 
 	// Populate cover
-	populateCover()
+	populateCover(projectName)
 
 	// Populate screens
-	populateScreens(path, templatePage, numberOfScreensPerPage, metadata[projectNameJSONKey], metadata[descriptionsJSONKey])
+	populateScreens(path, templatePage, numberOfScreensPerPage, projectName, descriptions)
 
 	// Remove template
 	removeTemplatePage()
@@ -63,12 +67,12 @@ function getTemplateScreens() {
     return getChildLayerByName(getFirstArtboard(), screensLayerGroupName)
 }
 
-function getFirstTemplatePage() {
+function getPageByName(pageName) {
 	var pages = doc.pages()
 	var pageLoop = pages.objectEnumerator()
 
     while (page = pageLoop.nextObject()) {
-        if( page.name() == templatePageName) {
+        if (page.name() == pageName) {
             return page
         }
     }
@@ -201,12 +205,19 @@ function duplicateTemplatePage(templatePage) {
     return newPage
 }
 
-function populateCover() {
-	print('populateCover')
+function populateCover(projectName) {
+    // Get the cover page and it's artboard
+    var coverPage = getPageByName(coverPageName)
+    var coverArtboard = coverPage.artboards().firstObject()
+
+    // Set the project name
+    setTextOnChildLayerByName(coverArtboard, coverProjectNameLayerName, projectName)
+
+    // TODO: Update the version number
 }
 
 function removeTemplatePage() {
-	var templatePage = getFirstTemplatePage()
+	var templatePage = getPageByName(templatePageName)
 	var pages = doc.pages()
 	print(templatePage)
 	print(pages)

--- a/Populate User Flows.sketchplugin
+++ b/Populate User Flows.sketchplugin
@@ -1,13 +1,16 @@
 // Populate User Flows (command control p)
 
+#import 'lib/constants.js'
+
 init()
 
 function init() {
 	var path = getExportsFolder()
 
-	// Get descriptions from descriptions.json
-	var pathToDescriptionsJson = path.URLByAppendingPathComponent('descriptions.json')
-	var descriptions = [NSString stringWithContentsOfURL:pathToDescriptionsJson encoding:NSUTF8StringEncoding error:null]
+	// Get metadata into a JSON object
+	var metadataFilePath = path.URLByAppendingPathComponent(metadataFilename)
+	var metadataString = [NSString stringWithContentsOfURL:metadataFilePath encoding:NSUTF8StringEncoding error:null]
+    var metadata = JSON.parse(metadataString)
 
 	// Select first template page
 	var templatePage = getFirstTemplatePage()
@@ -19,7 +22,7 @@ function init() {
 	populateCover()
 
 	// Populate screens
-	populateScreens(path, templatePage, numberOfScreensPerPage, descriptions)
+	populateScreens(path, templatePage, numberOfScreensPerPage, metadata[descriptionsJSONKey])
 
 	// Remove template
 	removeTemplatePage()
@@ -135,8 +138,7 @@ function populateScreens(path, templatePage, numberOfScreensPerPage, description
 		            setTextOnChildLayerByName( screenGroup, "Heading", screenName )
 
 		            // Update description
-	                var descriptionsJSON = JSON.parse(descriptions)
-				    var description = descriptionsJSON[sectionName][filename]
+				    var description = descriptions[sectionName][filename]
 
 				    if (typeof description != 'string') {
 				    	description = ""

--- a/Populate User Flows.sketchplugin
+++ b/Populate User Flows.sketchplugin
@@ -22,7 +22,7 @@ function init() {
 	populateCover()
 
 	// Populate screens
-	populateScreens(path, templatePage, numberOfScreensPerPage, metadata[descriptionsJSONKey])
+	populateScreens(path, templatePage, numberOfScreensPerPage, metadata[projectNameJSONKey], metadata[descriptionsJSONKey])
 
 	// Remove template
 	removeTemplatePage()
@@ -51,7 +51,7 @@ function getScreensPerPageFromTemplate(templatePage) {
     var artboard = templatePage.artboards().firstObject()
 
 	// Get Screens group
-	var screens = getChildLayerByName(artboard, 'Screens')
+	var screens = getChildLayerByName(artboard, screensLayerGroupName)
 
     // Get number of children in Screens group
     return screens.layers().length()
@@ -60,7 +60,7 @@ function getScreensPerPageFromTemplate(templatePage) {
 
 // Get the 'Screens' group
 function getTemplateScreens() {
-    return getChildLayerByName(getFirstArtboard(), 'Screens')
+    return getChildLayerByName(getFirstArtboard(), screensLayerGroupName)
 }
 
 function getFirstTemplatePage() {
@@ -68,7 +68,7 @@ function getFirstTemplatePage() {
 	var pageLoop = pages.objectEnumerator()
 
     while (page = pageLoop.nextObject()) {
-        if( page.name() == 'Template') {
+        if( page.name() == templatePageName) {
             return page
         }
     }
@@ -78,7 +78,7 @@ function getFirstTemplatePage() {
 
 
 // Populate screens
-function populateScreens(path, templatePage, numberOfScreensPerPage, descriptions) {
+function populateScreens(path, templatePage, numberOfScreensPerPage, projectName, descriptions) {
 	var fileManager = NSFileManager.defaultManager()
     var folders = fileManager.shallowSubpathsOfDirectoryAtURL(path)
 
@@ -119,7 +119,7 @@ function populateScreens(path, templatePage, numberOfScreensPerPage, description
 					var screenGroup = templateScreens.layers().array()[screenCount]
 
 			    	// Get image layer
-			    	var imageLayer = getChildLayerByName(screenGroup, "Placeholder")
+			    	var imageLayer = getChildLayerByName(screenGroup, screenPlaceholderLayerName)
 
 			    	// // Get image data
 		            var data = fileManager.contentsAtPath(file)
@@ -132,10 +132,10 @@ function populateScreens(path, templatePage, numberOfScreensPerPage, description
 		            imageLayer.image = imageData
 
 		            // Update screen number
-		            setTextOnChildLayerByName( screenGroup, "Number", screenNumber )
+		            setTextOnChildLayerByName( screenGroup, screenNumberLayerName, screenNumber )
 
 		            // Update heading text
-		            setTextOnChildLayerByName( screenGroup, "Heading", screenName )
+		            setTextOnChildLayerByName( screenGroup, screenHeadingLayerName, screenName )
 
 		            // Update description
 				    var description = descriptions[sectionName][filename]
@@ -143,12 +143,13 @@ function populateScreens(path, templatePage, numberOfScreensPerPage, description
 				    if (typeof description != 'string') {
 				    	description = ""
 				    }
-		            setTextOnChildLayerByName( screenGroup, "Description", description )
+		            setTextOnChildLayerByName( screenGroup, screenDescriptionLayerName, description )
 
 		            // If it's the first screen on a page, update page title
 		            if (screenCount === 0) {
-			            var header = getChildLayerByName(getFirstArtboard(), "Header")
-			            setTextOnChildLayerByName(header, "Section name", sectionName)
+			            var header = getChildLayerByName(getFirstArtboard(), headerLayerName)
+                        setTextOnChildLayerByName(header, projectNameLayerName, projectName)
+                        setTextOnChildLayerByName(header, sectionNameLayerName, sectionName)
 
 		            	page.setName(sectionName)
 			        }
@@ -165,7 +166,7 @@ function populateScreens(path, templatePage, numberOfScreensPerPage, description
 					var slotsLeft = numberOfScreensPerPage - (screenCount % numberOfScreensPerPage)
 
 					// Remove empty slots
-		            var screens = getChildLayerByName(getFirstArtboard(), "Screens")
+		            var screens = getChildLayerByName(getFirstArtboard(), screensLayerGroupName)
 					for (var j=0; j<slotsLeft; j++) {
 						screens.removeLayer(screens.lastLayer())
 					}

--- a/Populate User Flows.sketchplugin
+++ b/Populate User Flows.sketchplugin
@@ -14,6 +14,8 @@ function init() {
 
     // Get the project name from the metadata
     var projectName = metadata[projectNameJSONKey]
+    // Get the document version from the metadata
+    var documentVersion = metadata[documentVersionJSONKey]
     // Get the descriptions from the metadata
     var descriptions = metadata[descriptionsJSONKey]
 
@@ -23,7 +25,7 @@ function init() {
 	var numberOfScreensPerPage = getScreensPerPageFromTemplate(templatePage)
 
 	// Populate cover
-	populateCover(projectName)
+	populateCover(projectName, documentVersion)
 
 	// Populate screens
 	populateScreens(path, templatePage, numberOfScreensPerPage, projectName, descriptions)
@@ -205,15 +207,19 @@ function duplicateTemplatePage(templatePage) {
     return newPage
 }
 
-function populateCover(projectName) {
+function populateCover(projectName, documentVersion) {
     // Get the cover page and it's artboard
     var coverPage = getPageByName(coverPageName)
     var coverArtboard = coverPage.artboards().firstObject()
 
+    // Get the cover header
+    // TODO: Remove the need to get the header by doing a deep search for layers in the page
+    var coverHeader = getChildLayerByName(coverArtboard, coverHeaderLayerGroupName)
+
     // Set the project name
     setTextOnChildLayerByName(coverArtboard, coverProjectNameLayerName, projectName)
-
-    // TODO: Update the version number
+    // Set the version number
+    setTextOnChildLayerByName(coverHeader, coverDocumentVersionLayerName, documentVersion)
 }
 
 function removeTemplatePage() {

--- a/README.md
+++ b/README.md
@@ -11,17 +11,7 @@ This plugin exports every artboard in your design document and allows you to cre
 4. Put those files in this folder
 
 # Compatibility
-Tested on Sketch 3.2.1
-
-# TODO
-
-## Export for User Flows:
-- Ask user for project name
-- Add (hidden) project name to meta page
-
-## Populate User Flows:
-- Update version and project name on cover page
-- Update project name on screen pages
+Tested on Sketch 3.2
 
 # Licence
 ```

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,14 @@
+/**
+ * This file contains all the constants that we use for the plugin.
+ **/
+
+// The name of the User Flow Description text layer
+var userFlowDescriptionLayerName = "User Flow Description"
+// The file extension to export the images with
+var fileExtension = ".png"
+// The filename to use for the descriptions file
+var descriptionsFilename = "user_flows.json"
+// The key used to reference the descriptions in the JSON file
+var descriptionsJSONKey = "descriptions"
+// The key used to reference the project name in the JSON file
+var projectNameJSONKey = "projectName"

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,7 @@ var userFlowDescriptionLayerName = "User Flow Description"
 // The file extension to export the images with
 var fileExtension = ".png"
 // The filename to use for the descriptions file
-var descriptionsFilename = "user_flows.json"
+var metadataFilename = "metadata.json"
 // The key used to reference the descriptions in the JSON file
 var descriptionsJSONKey = "descriptions"
 // The key used to reference the project name in the JSON file

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,8 +2,28 @@
  * This file contains all the constants that we use for the plugin.
  **/
 
-// The name of the User Flow Description text layer
+// The name of the User Flow Description text layer in the designs document
 var userFlowDescriptionLayerName = "User Flow Description"
+
+// The name of the page in the template document to duplicate and populate
+var templatePageName = "Template"
+// The name of the header layer in the template document
+var headerLayerName = "Header"
+// The name of the project name text layer in the template header layer
+var projectNameLayerName = "Project name"
+// The name of the section name text layer in the template header layer
+var sectionNameLayerName = "Section name"
+// The name of the screens layer group in the template document
+var screensLayerGroupName = "Screens"
+// The name of the screen number text layer in the screen layer group
+var screenNumberLayerName = "Number"
+// The name of the screen heading text layer in the screen layer group
+var screenHeadingLayerName = "Heading"
+// The name of the screen description text layer in the screen layer group
+var screenDescriptionLayerName = "Description"
+// The name of the screen placeholder image layer in the screen layer group
+var screenPlaceholderLayerName = "Placeholder"
+
 // The file extension to export the images with
 var fileExtension = ".png"
 // The filename to use for the descriptions file

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -25,8 +25,12 @@ var screenDescriptionLayerName = "Description"
 var screenPlaceholderLayerName = "Placeholder"
 // The name of the cover page in the template document
 var coverPageName = "Cover"
-// The name of the project name later on the cover page
+// The name of the header layer group on the cover page
+var coverHeaderLayerGroupName = "Header"
+// The name of the project name layer on the cover page
 var coverProjectNameLayerName = "Company name"
+// The name of the document version layer on the cover page
+var coverDocumentVersionLayerName = "Version"
 
 // The file extension to export the images with
 var fileExtension = ".png"
@@ -36,3 +40,5 @@ var metadataFilename = "metadata.json"
 var descriptionsJSONKey = "descriptions"
 // The key used to reference the project name in the JSON file
 var projectNameJSONKey = "projectName"
+// The key used to reference the document version in the JSON file
+var documentVersionJSONKey = "documentVersion"

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,6 +23,10 @@ var screenHeadingLayerName = "Heading"
 var screenDescriptionLayerName = "Description"
 // The name of the screen placeholder image layer in the screen layer group
 var screenPlaceholderLayerName = "Placeholder"
+// The name of the cover page in the template document
+var coverPageName = "Cover"
+// The name of the project name later on the cover page
+var coverProjectNameLayerName = "Company name"
 
 // The file extension to export the images with
 var fileExtension = ".png"


### PR DESCRIPTION
- Ask for project name and document version when exporting
- Guess the project name and document version from the filename which is usually in the format: `project_visuals_1.4.sketch`
- Save these values into the metadata JSON file
- Populate the project name on each template page
- Populate the cover page with the project name and document version
- Moved the constants (file names, layer names etc.) into a shared file to decrease the chances of the two plugin actions falling out of sync
- Remove the completed TODOs from the README
